### PR TITLE
type luya module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "oom/luya-module-apiauth",
-    "type": "luya-extension",
+    "type": "luya-module",
     "minimum-stability": "stable",
     "license":"MIT",
     "authors": [


### PR DESCRIPTION
since the module must be implemented in the config in order to work, this must be type luya-module instead of extension.